### PR TITLE
Pull latest directly from S3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl \
       -f \
       -k \
       -o /usr/local/bin/hoarder \
-      https://d3ep67zochz54j.cloudfront.net/hoarder/linux/amd64/hoarder && \
+      https://s3.amazonaws.com/tools.nanopack.io/hoarder/linux/amd64/hoarder && \
     chmod 755 /usr/local/bin/hoarder
 
 # Download md5 (used to perform updates in hooks)
@@ -25,14 +25,14 @@ RUN curl \
       -f \
       -k \
       -o /var/nanobox/hoarder.md5 \
-      https://d3ep67zochz54j.cloudfront.net/hoarder/linux/amd64/hoarder.md5
+      https://s3.amazonaws.com/tools.nanopack.io/hoarder/linux/amd64/hoarder.md5
 
 # Download slurp
 RUN curl \
       -f \
       -k \
       -o /usr/local/bin/slurp \
-      https://d3ep67zochz54j.cloudfront.net/slurp/linux/amd64/slurp && \
+      https://s3.amazonaws.com/tools.nanopack.io/slurp/linux/amd64/slurp && \
     chmod 755 /usr/local/bin/slurp
 
 # Download md5 (used to perform updates in hooks)
@@ -40,13 +40,13 @@ RUN curl \
       -f \
       -k \
       -o /var/nanobox/slurp.md5 \
-      https://d3ep67zochz54j.cloudfront.net/slurp/linux/amd64/slurp.md5
+      https://s3.amazonaws.com/tools.nanopack.io/slurp/linux/amd64/slurp.md5
 
 # Install hooks
 RUN curl \
       -f \
       -k \
-      https://d1ormdui8qdvue.cloudfront.net/hooks/hoarder-stable.tgz \
+      https://s3.amazonaws.com/tools.nanobox.io/hooks/hoarder-stable.tgz \
         | tar -xz -C /opt/nanobox/hooks
 
 # Download hooks md5 (used to perform updates)
@@ -54,7 +54,7 @@ RUN curl \
       -f \
       -k \
       -o /var/nanobox/hooks.md5 \
-      https://d1ormdui8qdvue.cloudfront.net/hooks/hoarder-stable.md5
+      https://s3.amazonaws.com/tools.nanobox.io/hooks/hoarder-stable.md5
 
 # Run runit automatically
 CMD [ "/opt/gonano/bin/nanoinit" ]


### PR DESCRIPTION
This may seem to take a little bit longer, but it is one time and will ensure
we get the latest version. (We'd otherwise have to wait for cloudfront before
building)